### PR TITLE
KillSwitch (SnakeGameEnd.bat)

### DIFF
--- a/SnakeGameEnd.bat
+++ b/SnakeGameEnd.bat
@@ -1,0 +1,1 @@
+taskkill /f /im KeyboardMinigames.exe /t


### PR DESCRIPTION
Kill Switch which can be bound to any key and closes KeyboardMinigames without using task manager or cmd(manually)
